### PR TITLE
Removed deprecated Visual Studio macro std::_USE

### DIFF
--- a/Tools/StdString.h
+++ b/Tools/StdString.h
@@ -756,7 +756,7 @@ inline const Type& SSMAX(const Type& arg1, const Type& arg2)
 
 	#elif defined(_MSC_VER )
 
-		#define SS_USE_FACET(loc, fac) std::_USE(loc, fac)
+		#define SS_USE_FACET(loc, fac) std::use_facet<fac>(loc)
 
 	// ...and
 	#elif defined(_RWSTD_NO_TEMPLATE_ON_RETURN_TYPE)


### PR DESCRIPTION
Removed deprecated Visual Studio macro "std::_USE(loc, fac)" as it fails to compile as of Visual Studio 2017 15.8.5, and replaced it with standard "std::use_facet<fac>(log)" as per explanation given by Microsoft here:

https://developercommunity.visualstudio.com/content/problem/263793/msvc-141426428-xlocale-missing-use-macro.html#reply-265857