### PR TITLE
Unicode fixes.

### DIFF
--- a/DeepSkyStacker/About.cpp
+++ b/DeepSkyStacker/About.cpp
@@ -52,7 +52,7 @@ BOOL CAbout::OnInitDialog()
 
 	strHTML += _T("<img valign=top align=right src=\"RES:LOGO.PNG\">");
 
-	strText.Format(IDS_ABOUT_DSS, VERSION_DEEPSKYSTACKER);
+	strText.Format(IDS_ABOUT_DSS, CString(VERSION_DEEPSKYSTACKER));
 	strText.Replace(_T("\n"), _T("<BR>"));
 	strText += _T("<BR>");
 	strText += _T(DSSVER_COPYRIGHT);
@@ -62,21 +62,21 @@ BOOL CAbout::OnInitDialog()
 	strHTML += strMask;
 
 
-	strText.Format(IDS_ABOUT_DCRAW, VERSION_DCRAW);
+	strText.Format(IDS_ABOUT_DCRAW, _T(VERSION_DCRAW));
 	strText.Replace(_T("\n"), _T("<BR>"));
 	strHTML += strText+_T("<br>");
 	strText.LoadString(IDS_ABOUT_DCRAW_LINK);
 	strMask.Format(_T("<a href=\"%s\">%s</a><br><br>"), (LPCTSTR)strText, (LPCTSTR)strText);
 	strHTML += strMask;
 
-	strText.Format(IDS_ABOUT_TIFF, VERSION_LIBTIFF);
+	strText.Format(IDS_ABOUT_TIFF, _T(VERSION_LIBTIFF));
 	strText.Replace(_T("\n"), _T("<BR>"));
 	strHTML += strText+_T("<br>");
 	strText.LoadString(IDS_ABOUT_TIFF_LINK);
 	strMask.Format(_T("<a href=\"%s\">%s</a><br><br>"), (LPCTSTR)strText, (LPCTSTR)strText);
 	strHTML += strMask;
 
-	strText.Format(IDS_ABOUT_FITS, VERSION_CFITSIO);
+	strText.Format(IDS_ABOUT_FITS, _T(VERSION_CFITSIO));
 	strText.Replace(_T("\n"), _T("<BR>"));
 	strHTML += strText+_T("<br>");
 	strText.LoadString(IDS_ABOUT_FITS_LINK);

--- a/DeepSkyStacker/FITSUtil.cpp
+++ b/DeepSkyStacker/FITSUtil.cpp
@@ -252,7 +252,7 @@ BOOL CFITSReader::ReadKey(LPSTR szKey, LONG & lValue)
 BOOL CFITSReader::ReadKey(LPSTR szKey, CString & strValue)
 {
 	BOOL				bResult = FALSE;
-	TCHAR				szValue[2000];
+	CHAR				szValue[2000];
 	int					nStatus = 0;
 
 	if (m_fits)
@@ -1202,7 +1202,7 @@ void	CFITSWriter::WriteAllKeys()
 		for (LONG i = 0;i<m_ExtraInfo.m_vExtras.size();i++)
 		{
 			CExtraInfo &ei = m_ExtraInfo.m_vExtras[i];
-			TCHAR			szValue[FLEN_VALUE];
+			CHAR			szValue[FLEN_VALUE];
 
 			// check that the keyword is not already used
 			fits_read_key(m_fits, TSTRING, (LPCSTR)CT2A(ei.m_strName, CP_UTF8), szValue, NULL, &nStatus);

--- a/DeepSkyStacker/Workspace.cpp
+++ b/DeepSkyStacker/Workspace.cpp
@@ -460,7 +460,7 @@ void	CWorkspaceSettingsInternal::InitToDefault(WORKSPACESETTINGVECTOR & vSetting
 	vSettings.push_back(CWorkspaceSetting(REGENTRY_BASEKEY_FITSSETTINGS, _T("Brighness"), 1.0));
 	vSettings.push_back(CWorkspaceSetting(REGENTRY_BASEKEY_FITSSETTINGS, _T("RedScale"), 1.0));
 	vSettings.push_back(CWorkspaceSetting(REGENTRY_BASEKEY_FITSSETTINGS, _T("BlueScale"), 1.0));
-	vSettings.push_back(CWorkspaceSetting(REGENTRY_BASEKEY_FITSSETTINGS, _T("DSLR"), ""));
+	vSettings.push_back(CWorkspaceSetting(REGENTRY_BASEKEY_FITSSETTINGS, _T("DSLR"), _T("")));
 	vSettings.push_back(CWorkspaceSetting(REGENTRY_BASEKEY_FITSSETTINGS, _T("BayerPattern"), (DWORD)4));
 	vSettings.push_back(CWorkspaceSetting(REGENTRY_BASEKEY_FITSSETTINGS, _T("Interpolation"), _T("Bilinear")));
 	vSettings.push_back(CWorkspaceSetting(REGENTRY_BASEKEY_FITSSETTINGS, _T("ForceUnsigned"), false));


### PR DESCRIPTION
This commit fixes the following issues with FITS files:
* Not saving DSLR (Camera Bayer pattern) setting in the FITS Files dialog (Workspace.cpp);
* Invalid FITS key values (FITSUtil.cpp).

Also a cosmetic fix is included (also related to char vs unicode mismatch):
* Incorrect displaying of various version strings in the About dialog (About.cpp).

Please consider merging these fixes.