### PR TITLE
SmartPtr.h: remove unnecessary and thread unsafe assignment.

### DIFF
--- a/Tools/SmartPtr.h
+++ b/Tools/SmartPtr.h
@@ -19,7 +19,7 @@ public :
 	void	AddRef()
 	{
 		#if defined(_WINDOWS_)
-		m_lRefCount = InterlockedIncrement(&m_lRefCount);
+		InterlockedIncrement(&m_lRefCount);
 		#else
 		m_lRefCount++;
 		#endif


### PR DESCRIPTION
This commit fixes sporadic crashes during registering or stacking caused by incorrect reference counting in CSmartPtr class.

I've seen these rare crashes when processing a large number of images (100+) on system which has 16 threads. The VisualStudio debugger showed that these crashes were caused by accessing a CMemoryBitmap where corresponding CSmartPtr::m_lRefCount is 0.

Googling "Deep Sky Stacker crash" also gives a few complains about sudden crashes during stacking,

It turned out that CSmartPtr::AddRef is not thread safe:
m_lRefCount = InterlockedIncrement(&m_lRefCount);
The m_lRefCount assignment is not necessary at all and introduces a race condition.
If thread1 executes InterlockedIncrement and then another thread2 increments m_lRefCount before the thread1 executes the assignment, then the thread2 increment will be lost.

The following diff makes the bug 100% reproducible by increasing the race window:
```
diff --git a/Tools/SmartPtr.h b/Tools/SmartPtr.h
index 60a55ef..172566f 100644
--- a/Tools/SmartPtr.h
+++ b/Tools/SmartPtr.h
@@ -19,7 +19,9 @@ public :
        void    AddRef()
        {
                #if defined(_WINDOWS_)
-               m_lRefCount = InterlockedIncrement(&m_lRefCount);
+               LONG l = InterlockedIncrement(&m_lRefCount);
+               Sleep(1);
+               m_lRefCount = l;
                #else
                m_lRefCount++;
                #endif
```
Please consider merging the fix. Thanks.