### PR TITLE
Change for the picture list column sorting comparator function to provide strict weak ordering

### DIFF
--- a/DeepSkyStacker/PictureListCtrl.cpp
+++ b/DeepSkyStacker/PictureListCtrl.cpp
@@ -304,7 +304,9 @@ int	CPictureListCtrl::CompareItems(LONG lItem1, LONG lItem2)
 				lResult = 0;
 			break;
 		case COLUMN_SCORE :
-			if (!m_vFiles[lItem1].IsLightFrame())
+			if (!m_vFiles[lItem1].IsLightFrame() && !m_vFiles[lItem2].IsLightFrame())
+				lResult = 0;
+			else if (!m_vFiles[lItem1].IsLightFrame())
 				lResult = -1;
 			else if (!m_vFiles[lItem2].IsLightFrame())
 				lResult = 1;
@@ -314,7 +316,9 @@ int	CPictureListCtrl::CompareItems(LONG lItem1, LONG lItem2)
 				lResult = 1;
 			break;
 		case COLUMN_DX :
-			if (!m_vFiles[lItem1].IsLightFrame())
+			if (!m_vFiles[lItem1].IsLightFrame() && !m_vFiles[lItem2].IsLightFrame())
+				lResult = 0;
+			else if (!m_vFiles[lItem1].IsLightFrame())
 				lResult = -1;
 			else if (!m_vFiles[lItem2].IsLightFrame())
 				lResult = 1;
@@ -324,7 +328,9 @@ int	CPictureListCtrl::CompareItems(LONG lItem1, LONG lItem2)
 				lResult = 1;
 			break;
 		case COLUMN_DY :
-			if (!m_vFiles[lItem1].IsLightFrame())
+			if (!m_vFiles[lItem1].IsLightFrame() && !m_vFiles[lItem2].IsLightFrame())
+				lResult = 0;
+			else if (!m_vFiles[lItem1].IsLightFrame())
 				lResult = -1;
 			else if (!m_vFiles[lItem2].IsLightFrame())
 				lResult = 1;
@@ -334,7 +340,9 @@ int	CPictureListCtrl::CompareItems(LONG lItem1, LONG lItem2)
 				lResult = 1;
 			break;
 		case COLUMN_ANGLE :
-			if (!m_vFiles[lItem1].IsLightFrame())
+			if (!m_vFiles[lItem1].IsLightFrame() && !m_vFiles[lItem2].IsLightFrame())
+				lResult = 0;
+			else if (!m_vFiles[lItem1].IsLightFrame())
 				lResult = -1;
 			else if (!m_vFiles[lItem2].IsLightFrame())
 				lResult = 1;


### PR DESCRIPTION
If the picture list contains both light frames and other frames, then STL complains (asserts) about 'invalid comparator' in debug build of DeepSkyStacker. This change provides strict weak ordering required by STL.

This does not have any effect on release builds.

Please merge anyway, because it makes debugging easier.

Thanks,
Vitali