### PR TITLE
Enhance Installers

### DIFF
--- a/Installers/DeepSkyStackerInstaller32.nsi
+++ b/Installers/DeepSkyStackerInstaller32.nsi
@@ -1,6 +1,10 @@
 ##!include "MUI2.nsh"
 !verbose 4
 
+!include "MUI.nsh"
+
+!define MUI_HEADERIMAGE
+
 !define PRODUCT_NAME       "DeepSkyStacker"
 !define NAMESUFFIX         " (32 bit)"
 
@@ -32,6 +36,7 @@
 
 !define DSS_README_NAME    "README"
 !define DSS_README_FILE    "README.txt"
+!define DSS_EULA		   "../LICENSE"
 
 
 !define DSS_UNINSTALL_NAME "DeepSkyStacker${NAMESUFFIX} Uninstaller"
@@ -40,7 +45,7 @@
 !define DSS_REG_UNINSTALL_PATH "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}32"
 
 CRCCheck On
-
+SetCompressor /SOLID lzma
 
 # define installer name
 
@@ -63,6 +68,12 @@ UninstallIcon         "${DSS_ICON}"
 
 var PreviousUninstaller
 
+# Add EULA and custom installation pages.
+!insertmacro MUI_PAGE_LICENSE "${DSS_EULA}"
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_LANGUAGE "English"
+
 # default installer section start
 
 Section
@@ -70,10 +81,6 @@ Section
   # Want to use "all users" area of StartMenu/Programs
   SetShellVarContext	all
   
-  # Modify UI behaviours
-  
-  SetDetailsPrint     both
-
   # define output path
 
   SetOutPath $INSTDIR
@@ -151,11 +158,6 @@ Section "Uninstall"
   # Want to use "all users" area of StartMenu/Programs
   SetShellVarContext	all
   
-  # Modify UI behaviours
-  
-  SetDetailsPrint     textonly
-
-
   # Always delete uninstaller first
 
   Delete "$INSTDIR\${DSS_UNINSTALL_FILE}.exe" 

--- a/Installers/DeepSkyStackerInstaller64.nsi
+++ b/Installers/DeepSkyStackerInstaller64.nsi
@@ -1,6 +1,10 @@
 ##!include "MUI2.nsh"
 !verbose 4
 
+!include "MUI.nsh"
+
+!define MUI_HEADERIMAGE
+
 !define PRODUCT_NAME       "DeepSkyStacker"
 !define NAMESUFFIX         " (64 bit)"
 
@@ -32,6 +36,7 @@
 
 !define DSS_README_NAME    "README"
 !define DSS_README_FILE    "README.txt"
+!define DSS_EULA		   "../LICENSE"
 
 
 !define DSS_UNINSTALL_NAME "DeepSkyStacker${NAMESUFFIX} Uninstaller"
@@ -40,7 +45,7 @@
 !define DSS_REG_UNINSTALL_PATH "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}64"
 
 CRCCheck On
-
+SetCompressor /SOLID lzma
 
 # define installer name
 
@@ -63,6 +68,12 @@ UninstallIcon         "${DSS_ICON}"
 
 var PreviousUninstaller
 
+# Add EULA and custom installation pages.
+!insertmacro MUI_PAGE_LICENSE "${DSS_EULA}"
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_LANGUAGE "English"
+
 # default installer section start
 
 Section
@@ -70,10 +81,6 @@ Section
   # Want to use "all users" area of StartMenu/Programs
   SetShellVarContext	all
   
-  # Modify UI behaviours
-  
-  SetDetailsPrint     both
-
   # define output path
 
   SetOutPath $INSTDIR
@@ -146,11 +153,6 @@ Section "Uninstall"
   # Want to use "all users" area of StartMenu/Programs
   SetShellVarContext	all
   
-  # Modify UI behaviours
-  
-  SetDetailsPrint     textonly
-
-
   # Always delete uninstaller first
 
   Delete "$INSTDIR\${DSS_UNINSTALL_FILE}.exe" 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2016, 2018, 2019, LucCoiffier; David C. Partridge
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
1) Added custom installation location option (requires mui header)
2) Verbose install/uninstall details (default when no SetDetailsPrint) so user can see exactly what is installed/removed during the process.
3) Set up use lzma compression for 20% installer size reduction.
4) Added initial license page that must be accepted to install.