### PR TITLE
Added Missing Installer Strings (English only)

### DIFF
--- a/Installers/DeepSkyStackerInstaller32.nsi
+++ b/Installers/DeepSkyStackerInstaller32.nsi
@@ -76,6 +76,12 @@ var PreviousUninstaller
 !insertmacro MUI_PAGE_INSTFILES
 !insertmacro MUI_LANGUAGE "English"
 
+${ReadmeLanguage} "${LANG_ENGLISH}" \
+          "Build Details" \
+          "Deep Sky Stacker Change List" \
+          "About $(^name):" \
+          "$\n  Click on scrollbar arrows or press Page Down to review the entire text."
+
 # default installer section start
 
 Section

--- a/Installers/DeepSkyStackerInstaller64.nsi
+++ b/Installers/DeepSkyStackerInstaller64.nsi
@@ -76,6 +76,12 @@ var PreviousUninstaller
 !insertmacro MUI_PAGE_INSTFILES
 !insertmacro MUI_LANGUAGE "English"
 
+${ReadmeLanguage} "${LANG_ENGLISH}" \
+          "Build Details" \
+          "Deep Sky Stacker Change List" \
+          "About $(^name):" \
+          "$\n  Click on scrollbar arrows or press Page Down to review the entire text."
+
 # default installer section start
 
 Section


### PR DESCRIPTION
Added missing installer read-me page strings. The title and sub title are easily configurable in the language section as desired.